### PR TITLE
Handle PBF files which don't have a bounding box in their headers

### DIFF
--- a/inc/data-bounds.py
+++ b/inc/data-bounds.py
@@ -20,7 +20,20 @@ pbf = result.stdout
 
 pbf_json = json.loads(pbf)
 
-bbox = pbf_json['header']['boxes'][0]
+try:
+    bbox = pbf_json['header']['boxes'][0]
+
+except:
+    print("Failed to read bounding box from file headers, falling back on searching all points in the file")
+
+    result = subprocess.run(['osmium', 'fileinfo', '-e', '-j', pbf_file], stdout=subprocess.PIPE)
+
+    pbf = result.stdout
+
+    pbf_json = json.loads(pbf)
+
+    bbox = pbf_json['data']['bbox']
+
 
 
 with open("bbox.wkt", 'w') as f:


### PR DESCRIPTION
Without this tweak, if there is no bounding box in the header file (as in files from downloads.openstreetmap.fr) then this script throws an exception and fails.

osmium can read the whole file and determine its own bounding box, which it now does if it isn't in the headers