### PR TITLE
Fix error: "Unknown value..."

### DIFF
--- a/inc/osm2pgsql-import.sh
+++ b/inc/osm2pgsql-import.sh
@@ -67,7 +67,7 @@ then
     systemctl start osm2pgsql-update.timer
 else
     # fallback: take timestamp from actual file contents
-    REPLICATION_TIMESTAMP=$(osmium fileinfo -e -g date.timestamp.last $OSM_EXTRACT)
+    REPLICATION_TIMESTAMP=$(osmium fileinfo -e -g metadata.all_objects.timestamp $OSM_EXTRACT)
 fi
 
 sudo -u maposmatic psql gis -c "update maposmatic_admin set last_update='$REPLICATION_TIMESTAMP'"


### PR DESCRIPTION
Fix error:
```
    default: Unknown value for --get/-g option 'date.timestamp.last'. Use --show-variables/-G to see list of known values.
    default: ERROR:  invalid input syntax for type timestamp: ""
    default: LINE 1: update maposmatic_admin set last_update=''
```

I'm not sure that I used valid equivalent.

Ocmium known variables:
```
root@42230edf3005:/# osmium fileinfo -e --show-variables
file.name
file.format
file.compression
file.size
header.with_history
header.option.generator
header.option.osmosis_replication_base_url
header.option.osmosis_replication_sequence_number
header.option.osmosis_replication_timestamp
header.option.pbf_dense_nodes
header.option.timestamp
header.option.version
data.bbox
data.timestamp.first
data.timestamp.last
data.objects_ordered
data.multiple_versions
data.crc32
data.count.nodes
data.count.ways
data.count.relations
data.count.changesets
data.minid.nodes
data.minid.ways
data.minid.relations
data.minid.changesets
data.maxid.nodes
data.maxid.ways
data.maxid.relations
data.maxid.changesets
data.buffers.count
data.buffers.size
data.buffers.capacity
metadata.all_objects.version
metadata.all_objects.timestamp
metadata.all_objects.changeset
metadata.all_objects.uid
metadata.all_objects.user
metadata.some_objects.version
metadata.some_objects.timestamp
metadata.some_objects.changeset
metadata.some_objects.uid
metadata.some_objects.user
```