### PR TITLE
Fix "Unknown value for --get/-g option 'date.timestamp.last'".

### DIFF
--- a/inc/osm2pgsql-import.sh
+++ b/inc/osm2pgsql-import.sh
@@ -70,7 +70,7 @@ fi
 if test -z "$REPLICATION_TIMESTAMP"
 then
     # fallback: take timestamp from actual file contents
-    REPLICATION_TIMESTAMP=$(osmium fileinfo -e -g date.timestamp.last $OSM_EXTRACT)
+    REPLICATION_TIMESTAMP=$(osmium fileinfo -e -g data.timestamp.last $OSM_EXTRACT)
 fi
 
 sudo -u maposmatic psql gis -c "update maposmatic_admin set last_update='$REPLICATION_TIMESTAMP'"


### PR DESCRIPTION
Fix error:
```
 default: Unknown value for --get/-g option 'date.timestamp.last'. Use --show-variables/-G to see list of known values.
 default: ERROR:  invalid input syntax for type timestamp: ""
 default: LINE 1: update maposmatic_admin set last_update=''
```