### PR TITLE
Fix typo in waymarkedtrails overlay group description

### DIFF
--- a/inc/overlays/waymarked-trails.ini
+++ b/inc/overlays/waymarked-trails.ini
@@ -1,6 +1,6 @@
 [waymarked_hiking]
 name= WayMarkedHiking-Overlay
-group= WayMaredTrails Routes
+group= WayMarkedTrails Routes
 description= Way Marked Trails - Hiking
 description.de= Way Mared Trails - Wanderwege
 path= @STYLEDIR@/waymarkedtrails-backend/hiking.xml
@@ -8,7 +8,7 @@ url=http://www.osm-baustelle.de/dokuwiki/doku.php?id=overlay:waymarked
 
 [waymarked_cycling]
 name= WayMarkedCycling-Overlay
-group= WayMaredTrails Routes
+group= WayMarkedTrails Routes
 description= Way Marked Trails - Cycling
 description.de= Way Marked Trails - Radrouten
 path= @STYLEDIR@/waymarkedtrails-backend/cycling.xml
@@ -16,7 +16,7 @@ url=http://www.osm-baustelle.de/dokuwiki/doku.php?id=overlay:waymarked
 
 [waymarked_mtb]
 name= WayMarkedMtb-Overlay
-group= WayMaredTrails Routes
+group= WayMarkedTrails Routes
 description= Way Marked Trails - Mtb
 description.de= Way Marked Trails - Mountain Bike Routen
 path= @STYLEDIR@/waymarkedtrails-backend/mtb.xml
@@ -24,7 +24,7 @@ url=http://www.osm-baustelle.de/dokuwiki/doku.php?id=overlay:waymarked
 
 [waymarked_riding]
 name= WayMarkedRiding-Overlay
-group= WayMaredTrails Routes
+group= WayMarkedTrails Routes
 description= Way Marked Trails - Riding
 description.de= Way Marked Trails - Reitrouten
 path= @STYLEDIR@/waymarkedtrails-backend/riding.xml
@@ -32,7 +32,7 @@ url=http://www.osm-baustelle.de/dokuwiki/doku.php?id=overlay:waymarked
 
 [waymarked_skating]
 name= WayMarkedSkating-Overlay
-group= WayMaredTrails Routes
+group= WayMarkedTrails Routes
 description= Way Marked Trails - Skating
 description.de= Way Marked Trails - Inline Skate Routen
 path= @STYLEDIR@/waymarkedtrails-backend/skating.xml
@@ -40,7 +40,7 @@ url=http://www.osm-baustelle.de/dokuwiki/doku.php?id=overlay:waymarked
 
 [waymarked_slopes]
 name= WayMarkedSlopes-Overlay
-group= WayMaredTrails Routes
+group= WayMarkedTrails Routes
 description= Way Marked Trails - Slopes 
 description.de= Way Marked Trails - Skilanglauf-Loipen
 path= @STYLEDIR@/waymarkedtrails-backend/slopes.xml


### PR DESCRIPTION
Found that typo on https://print.get-map.org. I hope this is the right repo for a fix.