### PR TITLE
Remove duplicated shapefiles download

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -231,16 +231,6 @@ banner "DEM setup"
 banner "renderer setup"
 . $INCDIR/ocitysmap.sh
 
-
-
-banner "shapefiles"
-# install shapefiles
-. $INCDIR/get-shapefiles.sh
-# set up shapefile update job
-cp $FILEDIR/systemd/shapefile-update.* /etc/systemd/system
-systemctl daemon-reload
-
-
 banner "styles"
 . $INCDIR/styles.sh
 


### PR DESCRIPTION
I believe the following files are present twice in the `provision.sh` only unintentionally:

```bash
banner "shapefiles"
# install shapefiles
. $INCDIR/get-shapefiles.sh
# set up shapefile update job
cp $FILEDIR/systemd/shapefile-update.* /etc/systemd/system
systemctl daemon-reload
```

This PR removes one of the occurrences. Not tested, this PR rather presents an idea with a proposed fix. (Will test when I get to work with a clean environmnet.) An alternate solution would be adding a comment explaining the reason behind the repetition.