### PR TITLE
Typos regarding osm2pgsql-flex

### DIFF
--- a/inc/osm2pgsql-import-flex.sh
+++ b/inc/osm2pgsql-import-flex.sh
@@ -9,7 +9,7 @@ OSM_EXTRACT="${OSM_EXTRACT:-/vagrant/data.osm.pbf}"
 
 DBNAME=osmcarto_flex
 
-if ! test -d $STYLEDIR/osm2pgsql-carto-flex
+if ! test -d $STYLEDIR/openstreetmap-carto-flex
 then
     cd $STYLEDIR
 

--- a/inc/osm2pgsql-import-flex.sh
+++ b/inc/osm2pgsql-import-flex.sh
@@ -9,12 +9,13 @@ OSM_EXTRACT="${OSM_EXTRACT:-/vagrant/data.osm.pbf}"
 
 DBNAME=osmcarto_flex
 
-if ! test -d $STYLEDIR/openstreetmap-carto-flex
+STYLENAME=openstreetmap-carto-flex
+if ! test -d $STYLEDIR/$STYLENAME
 then
     cd $STYLEDIR
 
-    git clone --quiet https://github.com/gravitystorm/openstreetmap-carto.git openstreetmap-carto-flex
-    cd openstreetmap-carto-flex
+    git clone --quiet https://github.com/gravitystorm/openstreetmap-carto.git $STYLENAME
+    cd $STYLENAME
     git checkout --quiet master
 fi
 
@@ -22,8 +23,6 @@ IMPORTDIR=$INSTALLDIR/import/osm2pgsql-flex
 mkdir -p $IMPORTDIR
 chown maposmatic $IMPORTDIR
 cd $IMPORTDIR
-
-STYLENAME=openstreetmap-carto-flex
 
 STYLE_FILE=$FILEDIR/osm2pgsql-flex/openstreetmap-carto-flex.lua
 

--- a/inc/osm2pgsql-update-flex.sh
+++ b/inc/osm2pgsql-update-flex.sh
@@ -6,7 +6,7 @@ OSM2PGSQL=/usr/local/bin/osm2pgsql
 DIR=$INSTALLDIR/import/osm2pgsql-flex
 
 STYLENAME=openstreetmap-carto-flex
-STYLE_FILE=$FILEDIR/som2pgsql-flex/openstreetmap-carto.style
+STYLE_FILE=$FILEDIR/osm2pgsql-flex/openstreetmap-carto.style
 
 FLAT_NODE_FILE=osm2pgsql-nodes.dat
 

--- a/inc/styles/osm-carto-flex.sh
+++ b/inc/styles/osm-carto-flex.sh
@@ -6,9 +6,9 @@
 
 cd $STYLEDIR
 
-if test -d osm2pgsql-carto-flex
+if test -d openstreetmap-carto-flex
 then
-  cd osm2pgsql-carto-flex
+  cd openstreetmap-carto-flex
 else
   git clone --quiet https://github.com/gravitystorm/openstreetmap-carto.git openstreetmap-carto-flex
   cd openstreetmap-carto-flex

--- a/inc/styles/osm-carto-flex.sh
+++ b/inc/styles/osm-carto-flex.sh
@@ -4,14 +4,15 @@
 #
 #----------------------------------------------------
 
-cd $STYLEDIR
+STYLENAME=openstreetmap-carto-flex
 
-if test -d openstreetmap-carto-flex
+cd $STYLEDIR
+if test -d $STYLENAME
 then
-  cd openstreetmap-carto-flex
+  cd 
 else
-  git clone --quiet https://github.com/gravitystorm/openstreetmap-carto.git openstreetmap-carto-flex
-  cd openstreetmap-carto-flex
+  git clone --quiet https://github.com/gravitystorm/openstreetmap-carto.git $STYLENAME
+  cd $STYLENAME
   git checkout --quiet master
 fi
 


### PR DESCRIPTION
These fixes are **not tested**, but I believe they fix some obvious typing mistakes.

Spotted a message something like the following in my terminal on a fresh `vagrant up`, I believe I fix the root cause with this PR:

```
 ____  _         _         ___  ____  __  __    ____           _          _____ _           
/ ___|| |_ _   _| | ___   / _ \/ ___||  \/  |  / ___|__ _ _ __| |_ ___   |  ___| | _____  __
\___ \| __| | | | |/ _ \ | | | \___ \| |\/| | | |   / _` | '__| __/ _ \  | |_  | |/ _ \ \/ /
 ___) | |_| |_| | |  __/ | |_| |___) | |  | | | |__| (_| | |  | || (_) | |  _| | |  __/>  < 
|____/ \__|\__, |_|\___|  \___/|____/|_|  |_|  \____\__,_|_|   \__\___/  |_|   |_|\___/_/\_\
           |___/                                                                            

Cloning into openstreetmap-carto-flex...
Error: openstreetmap-carto-flex already exists and is not empty
```

(the above is not a copy-paste)

It seems like the commit https://github.com/hholzgra/maposmatic-vagrant/commit/f85ab0ba8697e5269b896e382b76cb0fa5f49bca had an error, which didn't come up until doing a clean run.

In addition, I found a typo, which suprisingly did not result in any error message.

Please check if my commits make sense.